### PR TITLE
Rename haystaa to leeyahay

### DIFF
--- a/docs/language/grammar.md
+++ b/docs/language/grammar.md
@@ -238,7 +238,7 @@ ListMethod ::= "kudar"       // push
 
 ```ebnf
 ObjectMethod ::= "fure"    // keys
-               | "haystaa"   // has
+               | "leeyahay"   // has
                | "tirtir"    // remove
                | "iskudar"   // merge
 ```

--- a/docs/language/keywords.md
+++ b/docs/language/keywords.md
@@ -118,7 +118,7 @@ This document provides a reference for all keywords in the Soplang programming l
 | Method    | Meaning             | English Equivalent   | Example                               |
 | --------- | ------------------- | -------------------- | ------------------------------------- |
 | `fure`  | Get object keys     | `keys`               | `door keys = myObj.fure()`          |
-| `haystaa` | Check if key exists | `has/hasOwnProperty` | `door exists = myObj.haystaa("name")` |
+| `leeyahay` | Check if key exists | `has/hasOwnProperty` | `door exists = myObj.leeyahay("name")` |
 | `tirtir`  | Remove property     | `delete`             | `myObj.tirtir("oldProp")`             |
 | `iskudar` | Merge objects       | `merge/assign`       | `door merged = obj1.iskudar(obj2)`    |
 

--- a/docs/testing/EXAMPLES.md
+++ b/docs/testing/EXAMPLES.md
@@ -228,7 +228,7 @@ docker run --rm -v "$(pwd):/scripts" soplang:latest examples/XX_example_name.so
 - Object creation and initialization
 - Property access with dot notation
 - Property modification
-- Object methods: `fure` (keys), `haystaa` (has), `tirtir` (remove), `iskudar` (merge)
+- Object methods: `fure` (keys), `leeyahay` (has), `tirtir` (remove), `iskudar` (merge)
 - Nested objects
 - Objects with arrays
 - Arrays of objects

--- a/examples/12_object_operations.sop
+++ b/examples/12_object_operations.sop
@@ -55,10 +55,10 @@ haddii (keys.dherer() > 0) {
 }
 
 // Check if property exists
-labadaran has_job = person.haystaa("shaqo")
+labadaran has_job = person.leeyahay("shaqo")
 qor("  Does person have 'shaqo'? " + has_job)
 
-labadaran has_email = person.haystaa("email")
+labadaran has_email = person.leeyahay("email")
 qor("  Does person have 'email'? " + has_email)
 
 // Removing properties

--- a/grammar.ebnf
+++ b/grammar.ebnf
@@ -193,6 +193,6 @@ ListMethod ::= "kudar"       // push
 
 // ===== OBJECT METHODS =====
 ObjectMethod ::= "fure"    // keys
-               | "haystaa"   // has
+               | "leeyahay"   // has
                | "tirtir"    // remove
                | "iskudar"   // merge

--- a/src/stdlib/builtins.py
+++ b/src/stdlib/builtins.py
@@ -312,7 +312,7 @@ def get_object_methods():
     """
     methods = {
         "fure": SoplangBuiltins.object_keys,
-        "haystaa": SoplangBuiltins.object_has,
+        "leeyahay": SoplangBuiltins.object_has,
         "tirtir": SoplangBuiltins.object_remove,
         "iskudar": SoplangBuiltins.object_merge
     }


### PR DESCRIPTION
🔄 Summary
This pull request renames all occurrences of the keyword heystaa to leeyahay for consistency and improved clarity across the language definition files.

✨ Changes
Renamed heystaa to leeyahay in the following files:

src/stdlib/builtins.py

examples/12_object_operations.sop

docs/testing/EXAMPLES.md

docs/language/keywords.md

docs/language/grammar.md

grammar.ebnf